### PR TITLE
fix: 修复除了贴吧链接之外其他正常链接被转义的问题

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -39,6 +39,9 @@ export default {
   },
   methods: {
     escape2Html(str) {
+      if (str.indexOf('//tieba.baidu.com/') === -1) {
+        return str;
+      }
       let temp = document.createElement('div');
       temp.innerHTML = str;
       const output = temp.innerText || temp.textContent;


### PR DESCRIPTION
微信链接 `http://mp.weixin.qq.com/s?src=11&timestamp=......` 中的 `&times` 被错误的转义为 `×`，导致页面无法打开。

其实贴吧的未转义问题应该由爬虫来解决吧，接口获取到的应该全部为合法的链接。
